### PR TITLE
Few small changes

### DIFF
--- a/articles/advanced-nestjs-dynamic-providers.md
+++ b/articles/advanced-nestjs-dynamic-providers.md
@@ -59,8 +59,7 @@ export class AppService {
 
 ## Setup a NestJS application
 
-We will make use of the NestJS CLI to get started quickly. If you have not installed it, use
-the following command:
+We will make use of the NestJS CLI to get started quickly. If you have not installed it, use the following command:
 
 ```bash
 npm i -g @nestjs/cli
@@ -74,8 +73,7 @@ nest new logger-app && cd logger-app
 
 ## Logger service
 
-Let's start off with our `LoggerService`. This service will get injected later when
-we use our `@Logger()`-decorator. Our basic requirements for this service are:
+Let's start off with our `LoggerService`. This service will get injected later when we use our `@Logger()` decorator. Our basic requirements for this service are:
 
 - A method which can log messages to stdout
 - A method which can set the prefix of each instance
@@ -116,11 +114,7 @@ export class LoggerService {
 }
 ```
 
-First of all, you may have realized that the `@Injectable()` decorator uses the
-scope option with `Scope.TRANSIENT`. This basically means every time the
-`LoggerService` gets injected in our application, it will create a new instance of
-the class. This is mandatory due to the `prefix` attribute. We do not want to
-have a single instance of the `LoggerService` and constantly override the `prefix` option.
+First of all, you may have realized that the `@Injectable()` decorator uses the scope option with `Scope.TRANSIENT`. This basically means every time the `LoggerService` gets injected in our application, it will create a new instance of the class. This is mandatory due to the `prefix` attribute. We do not want to have a single instance of the `LoggerService` and constantly override the `prefix` option.
 
 Other than that, the `LoggerService` should be self-explanatory.
 
@@ -161,9 +155,7 @@ export class AppService {
 
 ```
 
-Seems fine - let's start the application with `npm run start` and request the website
-with `curl http://localhost:3000/` or open up `http://localhost:3000` in
-your browser of choice.
+Seems fine - let's start the application with `npm run start` and request the website with `curl http://localhost:3000/` or open up `http://localhost:3000` in your browser of choice.
 
 If everything is set up correctly we will receive the following log output.
 
@@ -171,17 +163,11 @@ If everything is set up correctly we will receive the following log output.
 [AppService] Hello World
 ```
 
-That is cool. Though, we are lazy, aren't we? We do not want to explicitly write
-`this.logger.setPrefix('AppService')` in the constructor of our services?
-Something like `@Logger('AppService')` before our `logger`-parameter would
-be way more verbose and we would not have to define a constructor every
-time we want to use our logger.
+That is cool. Though, we are lazy, aren't we? We do not want to explicitly write `this.logger.setPrefix('AppService')` in the constructor of our services? Something like `@Logger('AppService')` before our `logger`-parameter would be way more verbose and we would not have to define a constructor every time we want to use our logger.
 
 ## Logger Decorator
 
-For our example, we do not need to exactly know how decorator works in
-TypeScript. All you need to know is that functions can be handled as
-a decorator.
+For our example, we do not need to exactly know how decorators work in TypeScript. All you need to know is that functions can be handled as a decorator.
 
 Lets quickly create our decorator manually.
 
@@ -207,14 +193,9 @@ export function Logger(prefix?: string) {
 
 ```
 
-You can think of `@Logger('AppService')` nothing more than an alias for
-`@Inject('LoggerServiceAppService')`. The only special thing we have added
-is the `prefixesForLoggers` array. We will make use of this array later. This array
-just stores all the prefixes we are going to need.
+You can think of `@Logger('AppService')` as nothing more than an alias for `@Inject('LoggerServiceAppService')`. The only special thing we have added is the `prefixesForLoggers` array. We will make use of this array later. This array just stores all the prefixes we are going to need.
 
-But wait, our Nest application does not know anything about a
-`LoggerServiceAppService` token? So let's create this token
-using dynamic providers and our newly created `prefixesForLoggers` array.
+But wait, our Nest application does not know anything about a `LoggerServiceAppService` token. So let's create this token using dynamic providers and our newly created `prefixesForLoggers` array.
 
 ## Dynamic providers
 
@@ -223,7 +204,7 @@ We want to
 
 - create a provider for each prefix
   - each of these providers must have a token like this `'LoggerService' + prefix`
-  - each provider must call `LoggerService.setPrefix(prefix)` upon its instanzation
+  - each provider must call `LoggerService.setPrefix(prefix)` upon its instantiation
 
 To implement these requirements we create a new file.
 
@@ -261,10 +242,7 @@ export function createLoggerProviders(): Array<Provider<LoggerService>> {
 
 ```
 
-The `createLoggerProviders`-function creates an array of providers for each
-prefix set by the `@Logger()` decorator. Thanks to the `useFactory`
-functionality of NestJS we can run a the `LoggerService.setPrefix()`
-method before the provider gets created.
+The `createLoggerProviders`-function creates an array of providers for each prefix set by the `@Logger()` decorator. Thanks to the `useFactory` functionality of NestJS we can run a the `LoggerService.setPrefix()` method before the provider gets created.
 
 All we need to do now is to add these logger providers to our `LoggerModule`.
 
@@ -286,18 +264,11 @@ export class LoggerModule {}
 
 ```
 
-As simple as that. Wait no, that does not work? Because of JavaScript, man.
-Let me explain `createLoggerProviders` will get called immediately once the file
-is loaded, right? At that point of time, the `prefixesForLoggers` array will
-be empty inside `logger.decorator.ts`, because the `@Logger()` decorator was
-not called. So how do we bypass that? The holy words are [*Dynamic Module*](https://docs.nestjs.com/modules#dynamic-modules).
-Dynamic modules allow us to create the module settings (which are usually
-given as parameter of the `@Module`-decorator) via a method. This
-method will get called after the `@Logger` decorator calls and
-therefore `prefixForLoggers` array will contain all the values.
+As simple as that. Wait no, that does not work? Because of JavaScript, man. Let me explain: `createLoggerProviders` will get called immediately once the file is loaded, right? At that point in time, the `prefixesForLoggers` array will be empty inside `logger.decorator.ts`, because the `@Logger()` decorator was not called. 
 
-If you want to learn more about why this works, you may wanna check out this
-[video about the JavaScript event loop](https://www.youtube.com/watch?v=8aGhZQkoFbQ)
+So how do we bypass that? The holy words are [*Dynamic Module*](https://docs.nestjs.com/modules#dynamic-modules).  Dynamic modules allow us to create the module settings (which are usually given as parameter of the `@Module`-decorator) via a method. This method will get called after the `@Logger` decorator calls and therefore `prefixForLoggers` array will contain all the values.
+
+If you want to learn more about why this works, you may wanna check out this [video about the JavaScript event loop](https://www.youtube.com/watch?v=8aGhZQkoFbQ)
 
 ```typescript
 // src/logger/logger.module.ts
@@ -333,7 +304,7 @@ export class AppModule { }
 
 ```
 
-and that's it! Lets if it works when we update the `app.service.ts`
+and that's it! Lets see if it works when we update the `app.service.ts`
 
 ```typescript
 // src/app.service.ts


### PR DESCRIPTION
Mainly, wrapping was off because of hard `\n`'s in the file.  E.g., 
```We will make use of the NestJS CLI to get started quickly. If you have not 
installed it, use
the following command:```

So I removed those.  Also made a couple small grammar and typo fixes.

Great stuff!!!!